### PR TITLE
Document new FIX tags for OSI

### DIFF
--- a/fix_trade_specification.md
+++ b/fix_trade_specification.md
@@ -83,8 +83,14 @@ This trade type represents a customer executing away from Clear Street LLC. For 
 | `Trade ID` | `17` |  | `String` |  | `R` | Unique Trade ID for this trade. Must be unique across days | `1234567890ABC` |
 | `Cancel Trade ID` | `9009` |  | `String` |  | `CR` | Original trade ID to cancel; Required for all Cancel trades | `ABC12345` |
 | `Trade Date` | `75` |  | `Integer` | `8` | `R` | Trade Date in `YYYYMMDD` format | `20201102` |
-| `Instrument Identifier Type` | `22` | `1` `2` `4` `8` | `Integer` | `1` | `R` | `1-CUSIP 2-SEDOL 4-ISIN 8-TICKER` | `8` |
-| `Instrument Identifier` | `48` |  | `String` |  | `R` | Instrument Identifier based on tag 22 | `AAPL` |
+| `Instrument Identifier Type` | `22` | `1` `2` `4` `8` | `Integer` | `1` | `CR` | `1-CUSIP 2-SEDOL 4-ISIN 8-TICKER` Required unless the instrument is an Option and tags 167, 55, 200, 201, 202, and 205 are provided. | `8` |
+| `Instrument Identifier` | `48` |  | `String` |  | `CR` | Instrument Identifier based on tag 22 Required unless the instrument is an Option and tags 167, 55, 200, 201, 202, and 205 are provided. | `AAPL` |
+| `Security Type` | `167` | | `String` | | `CR` | Indicates type of security. Required for Options where tags 22 or 48 are not provided. | `OPT` |
+| `Symbol` | `55` | | `String` | `6` | `CR` | Ticker symbol. Required for Options where tags 22 or 48 are not provided. | `SPY` |
+| `Maturity Month Year` | `200` | | `Integer` | `6` | `CR` | Month and year of the maturity for an Option. Maturity Month Year in format `YYYYMM`. Required for Options where tags 22 or 48 are not provided. | `202107` |
+| `Put Or Call` | `201` | `0` `1` | `Integer` | `1` | `CR` | Indicates whether an Option is for a put or a call `0 = Put` `1 = Call` Required for Options where tags 22 or 48 are not provided. | `1` |
+| `Strike Price` | `202` | | `Decimal` | `8` | `CR` | Strike Price for an Option. Required for Options where tags 22 or 48 are not provided. | `100.50` |
+| `Maturity Day` | `205` | | `Integer` | `2` | `CR` | To be used in conjunction with Maturity Month Year `200` to sepcify a particular maturity date for an Option. Required for Options where tags 22 or 48 are not provided. | `30` | 
 | `Instrument Country` | `421` |  | `String` | `3` | `R` | ISO 3166 alpha-3 country code where the instrument trades | `USA` |
 | `Instrument Currency` | `15` |  | `String` | `3` | `R` | ISO 4217 alpha-3 currency code in which the instrument trades | `USD` |
 | `Price` | `31` |  | `Decimal` |  | `R` | The price of the trade | `120.12` |
@@ -129,8 +135,14 @@ This trade represents a trade between two trading entities. For example, trading
 | `Trade ID` | `17` |  | `String` |  | `R` | Unique Trade ID for this trade. Must be unique across days | `1234567890ABC` |
 | `Cancel Trade ID` | `9009` |  | `String` |  | `CR` | Original trade ID to cancel; Required for all Cancel trades | `ABC12345` |
 | `Trade Date` | `75` |  | `Integer` | `8` | `R` | Trade Date in `YYYYMMDD` format | `20201102` |
-| `Instrument Identifier Type` | `22` | `1` `2` `4` `8` | `Integer` | `1` | `R` | `1-CUSIP 2-SEDOL 4-ISIN 8-TICKER` | `8` |
-| `Instrument Identifier` | `48` |  | `String` |  | `R` | Instrument Identifier based on tag 22 | `AAPL` |
+| `Instrument Identifier Type` | `22` | `1` `2` `4` `8` | `Integer` | `1` | `CR` | `1-CUSIP 2-SEDOL 4-ISIN 8-TICKER` Required unless the instrument is an Option and tags 167, 55, 200, 201, 202, and 205 are provided. | `8` |
+| `Instrument Identifier` | `48` |  | `String` |  | `CR` | Instrument Identifier based on tag 22 Required unless the instrument is an Option and tags 167, 55, 200, 201, 202, and 205 are provided. | `AAPL` |
+| `Security Type` | `167` | | `String` | | `CR` | Indicates type of security. Required for Options where tags 22 or 48 are not provided. | `OPT` |
+| `Symbol` | `55` | | `String` | `6` | `CR` | Ticker symbol. Required for Options where tags 22 or 48 are not provided. | `SPY` |
+| `Maturity Month Year` | `200` | | `Integer` | `6` | `CR` | Month and year of the maturity for an Option. Maturity Month Year in format `YYYYMM`. Required for Options where tags 22 or 48 are not provided. | `202107` |
+| `Put Or Call` | `201` | `0` `1` | `Integer` | `1` | `CR` | Indicates whether an Option is for a put or a call `0 = Put` `1 = Call` Required for Options where tags 22 or 48 are not provided. | `1` |
+| `Strike Price` | `202` | | `Decimal` | `8` | `CR` | Strike Price for an Option. Required for Options where tags 22 or 48 are not provided. | `100.50` |
+| `Maturity Day` | `205` | | `Integer` | `2` | `CR` | To be used in conjunction with Maturity Month Year `200` to sepcify a particular maturity date for an Option. Required for Options where tags 22 or 48 are not provided. | `30` | 
 | `Instrument Country` | `421` |  | `String` | `3` | `R` | ISO 3166 alpha-3 country code where the instrument trades | `USA` |
 | `Instrument Currency` | `15` |  | `String` | `3` | `R` | ISO 4217 alpha-3 currency code in which the instrument trades | `USD` |
 | `Price` | `31` |  | `Decimal` |  | `R` | The price of the trade | `120.12` |
@@ -176,8 +188,14 @@ This trade represents a trade between a trading entity and an exchange. For exam
 | `Trade ID` | `17` |  | `String` |  | `R` | Unique Trade ID for this trade. Must be unique across days | `1234567890ABC` |
 | `Cancel Trade ID` | `9009` |  | `String` |  | `CR` | Original trade ID to cancel; Required for all Cancel trades | `ABC12345` |
 | `Trade Date` | `75` |  | `Integer` | `8` | `R` | Trade Date in `YYYYMMDD` format | `20201102` |
-| `Instrument Identifier Type` | `22` | `1` `2` `4` `8` | `Integer` | `1` | `R` | `1-CUSIP 2-SEDOL 4-ISIN 8-TICKER` | `8` |
-| `Instrument Identifier` | `48` |  | `String` |  | `R` | Instrument Identifier based on tag 22 | `AAPL` |
+| `Instrument Identifier Type` | `22` | `1` `2` `4` `8` | `Integer` | `1` | `CR` | `1-CUSIP 2-SEDOL 4-ISIN 8-TICKER` Required unless the instrument is an Option and tags 167, 55, 200, 201, 202, and 205 are provided. | `8` |
+| `Instrument Identifier` | `48` |  | `String` |  | `CR` | Instrument Identifier based on tag 22 Required unless the instrument is an Option and tags 167, 55, 200, 201, 202, and 205 are provided. | `AAPL` |
+| `Security Type` | `167` | | `String` | | `CR` | Indicates type of security. Required for Options where tags 22 or 48 are not provided. | `OPT` |
+| `Symbol` | `55` | | `String` | `6` | `CR` | Ticker symbol. Required for Options where tags 22 or 48 are not provided. | `SPY` |
+| `Maturity Month Year` | `200` | | `Integer` | `6` | `CR` | Month and year of the maturity for an Option. Maturity Month Year in format `YYYYMM`. Required for Options where tags 22 or 48 are not provided. | `202107` |
+| `Put Or Call` | `201` | `0` `1` | `Integer` | `1` | `CR` | Indicates whether an Option is for a put or a call `0 = Put` `1 = Call` Required for Options where tags 22 or 48 are not provided. | `1` |
+| `Strike Price` | `202` | | `Decimal` | `8` | `CR` | Strike Price for an Option. Required for Options where tags 22 or 48 are not provided. | `100.50` |
+| `Maturity Day` | `205` | | `Integer` | `2` | `CR` | To be used in conjunction with Maturity Month Year `200` to sepcify a particular maturity date for an Option. Required for Options where tags 22 or 48 are not provided. | `30` | 
 | `Instrument Country` | `421` |  | `String` | `3` | `R` | ISO 3166 alpha-3 country code where the instrument trades | `USA` |
 | `Instrument Currency` | `15` |  | `String` | `3` | `R` | ISO 4217 alpha-3 currency code in which the instrument trades | `USD` |
 | `Price` | `31` |  | `Decimal` |  | `R` | The price of the trade | `120.12` |
@@ -220,8 +238,14 @@ This trade type is to facilitate trade movement between Clear Street internal ac
 | `Trade ID` | `17` |  | `String` |  | `R` | Unique Trade ID for this trade. Must be unique across days | `1234567890ABC` |
 | `Cancel Trade ID` | `9009` |  | `String` |  | `CR` | Original trade ID to cancel; Required for all Cancel trades | `ABC12345` |
 | `Trade Date` | `75` |  | `Integer` | `8` | `R` | Trade Date in `YYYYMMDD` format | `20201102` |
-| `Instrument Identifier Type` | `22` | `1` `2` `4` `8` | `Integer` | `1` | `R` | `1-CUSIP 2-SEDOL 4-ISIN 8-TICKER` | `8` |
-| `Instrument Identifier` | `48` |  | `String` |  | `R` | Instrument Identifier based on tag 22 | `AAPL` |
+| `Instrument Identifier Type` | `22` | `1` `2` `4` `8` | `Integer` | `1` | `CR` | `1-CUSIP 2-SEDOL 4-ISIN 8-TICKER` Required unless the instrument is an Option and tags 167, 55, 200, 201, 202, and 205 are provided. | `8` |
+| `Instrument Identifier` | `48` |  | `String` |  | `CR` | Instrument Identifier based on tag 22 Required unless the instrument is an Option and tags 167, 55, 200, 201, 202, and 205 are provided. | `AAPL` |
+| `Security Type` | `167` | | `String` | | `CR` | Indicates type of security. Required for Options where tags 22 or 48 are not provided. | `OPT` |
+| `Symbol` | `55` | | `String` | `6` | `CR` | Ticker symbol. Required for Options where tags 22 or 48 are not provided. | `SPY` |
+| `Maturity Month Year` | `200` | | `Integer` | `6` | `CR` | Month and year of the maturity for an Option. Maturity Month Year in format `YYYYMM`. Required for Options where tags 22 or 48 are not provided. | `202107` |
+| `Put Or Call` | `201` | `0` `1` | `Integer` | `1` | `CR` | Indicates whether an Option is for a put or a call `0 = Put` `1 = Call` Required for Options where tags 22 or 48 are not provided. | `1` |
+| `Strike Price` | `202` | | `Decimal` | `8` | `CR` | Strike Price for an Option. Required for Options where tags 22 or 48 are not provided. | `100.50` |
+| `Maturity Day` | `205` | | `Integer` | `2` | `CR` | To be used in conjunction with Maturity Month Year `200` to sepcify a particular maturity date for an Option. Required for Options where tags 22 or 48 are not provided. | `30` | 
 | `Instrument Country` | `421` |  | `String` | `3` | `R` | ISO 3166 alpha-3 country code where the instrument trades | `USA` |
 | `Instrument Currency` | `15` |  | `String` | `3` | `R` | ISO 4217 alpha-3 currency code in which the instrument trades | `USD` |
 | `Price` | `31` |  | `Decimal` |  | `R` | The price of the trade | `120.12` |

--- a/fix_trade_specification.md
+++ b/fix_trade_specification.md
@@ -37,8 +37,14 @@ This trade type is used to facilitate average-price workflows, i.e. averaging ma
 | `Trade ID` | `17` |  | `String` |  | `R` | Unique Trade ID for this trade. Must be unique across days | `1234567890ABC` |
 | `Cancel Trade ID` | `9009` |  | `String` |  | `CR` | Original trade ID to cancel; Required for all Cancel trades | `ABC12345` |
 | `Trade Date` | `75` |  | `Integer` | `8` | `R` | Trade Date in `YYYYMMDD` format | `20201102` |
-| `Instrument Identifier Type` | `22` | `1` `2` `4` `8` | `Integer` | `1` | `R` | `1-CUSIP 2-SEDOL 4-ISIN 8-TICKER` | `8` |
-| `Instrument Identifier` | `48` |  | `String` |  | `R` | Instrument Identifier based on tag 22 | `AAPL` |
+| `Instrument Identifier Type` | `22` | `1` `2` `4` `8` | `Integer` | `1` | `CR` | `1-CUSIP 2-SEDOL 4-ISIN 8-TICKER` Required unless the instrument is an Option and tags 167, 55, 200, 201, 202, and 205 are provided. | `8` |
+| `Instrument Identifier` | `48` |  | `String` |  | `CR` | Instrument Identifier based on tag 22 Required unless the instrument is an Option and tags 167, 55, 200, 201, 202, and 205 are provided. | `AAPL` |
+| `Security Type` | `167` | | `String` | | `CR` | Indicates type of security. Required for Options where tags 22 or 48 are not provided. | `OPT` |
+| `Symbol` | `55` | | `String` | `6` | `CR` | Ticker symbol. Required for Options where tags 22 or 48 are not provided. | `SPY` |
+| `Maturity Month Year` | `200` | | `Integer` | `6` | `CR` | Month and year of the maturity for an Option. Maturity Month Year in format `YYYYMM`. Required for Options where tags 22 or 48 are not provided. | `202107` |
+| `Put Or Call` | `201` | `0` `1` | `Integer` | `1` | `CR` | Indicates whether an Option is for a put or a call `0 = Put` `1 = Call` Required for Options where tags 22 or 48 are not provided. | `1` |
+| `Strike Price` | `202` | | `Decimal` | `8` | `CR` | Strike Price for an Option. Required for Options where tags 22 or 48 are not provided. | `100.50` |
+| `Maturity Day` | `205` | | `Integer` | `2` | `CR` | To be used in conjunction with Maturity Month Year `200` to sepcify a particular maturity date for an Option. Required for Options where tags 22 or 48 are not provided. | `30` | 
 | `Instrument Country` | `421` |  | `String` | `3` | `R` | ISO 3166 alpha-3 country code where the instrument trades | `USA` |
 | `Instrument Currency` | `15` |  | `String` | `3` | `R` | ISO 4217 alpha-3 currency code in which the instrument trades | `USD` |
 | `Price` | `31` |  | `Decimal` |  | `R` | The price of the trade | `120.12` |


### PR DESCRIPTION
Added tags 167, 55, 200, 201, 202, and 205 and updated tags 22 and 48 to reflect a new option for submitting FIX option messages.