### PR TITLE
[sc-29354] Update trade spec to relax requirements around providing timestamp on AWAY trades

### DIFF
--- a/trade_file.md
+++ b/trade_file.md
@@ -211,7 +211,7 @@ This trade type allows customers to execute away from Clear Street. An example w
 | - | - | - | - |
 | `type` | Yes |
 | `client_trade_id` | Yes |
-| `timestamp` | Yes |
+| `timestamp` | No | Derived Value | If not supplied the value will default to the time the trade is ingested into the back office |
 | `date` | Yes |
 | `account_id` | Yes |
 | `quantity` | Yes |


### PR DESCRIPTION
- Updates trade spec to remove requirement for the timestamp column in AWAY trades